### PR TITLE
Always use `bytes` as name of package

### DIFF
--- a/bytes.opam
+++ b/bytes.opam
@@ -11,4 +11,4 @@ depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "1.0"}
 ]
-build: ["dune" "build" "-p" name "-j" jobs]
+build: ["dune" "build" "-p" "bytes" "-j" jobs]


### PR DESCRIPTION
When `base-bytes.base+dune` is installed via OPAM, it passes `-p base-bytes` to dune which then fails. One possibility is to have an additional package but another one is to just hardcode `bytes` into the OPAM file which should achieve the same effect.

Reported in https://github.com/tarides/opam-monorepo/issues/343